### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ string request = "<?xml version=\"1.0\"?>\n"
 			+ "</TStream>\n";
 
 // Process the XML request
-_pdcx.ServerIPConfig("x1.mercurydev.net;x2.mercurydev.net", processControl);
+_pdcx.ServerIPConfig("x1.mercurycert.net;x2.mercurycert.net", processControl);
 _pdcx.SetConnectTimeout((short)5);
 _pdcx.SetResponseTimeout((short)60);
 string response = _pdcx.ProcessTransaction(request, 1, string.Empty, string.Empty);


### PR DESCRIPTION
I don't know if it's intentional, but x1.mercurydev.net and x1.mercurydev.net are both currently refusing connections on port 9000 (although they do still accept connections on 9100). A request to either of those servers without an `<IpPort>` like the example fails with "No connection to any server".